### PR TITLE
Add default expression as comment suggestion in query

### DIFF
--- a/config_local.yaml
+++ b/config_local.yaml
@@ -5,3 +5,12 @@ importer:
 exporter:
   folder:
     path: ./tt_promql
+
+# The best practice is to initialize the measurement with the default values in code.
+# However, if not possible then set the default_measurement to true. This will provide
+# suggestion to append below promql query to the output query.
+# + <aggregation> by [group_by] (
+#    (metric{label_filter} unless metric{label_filter} offset <time>)
+#   or metric{label_filter} offset <time> * 0
+#  )
+default_measurement: true

--- a/main.py
+++ b/main.py
@@ -60,10 +60,11 @@ def run():
     config = build_module_list_from_config(module_names, modules)
     datasource_mapping = construct_datasource_mapping()
     logging.getLogger(__name__).setLevel(level=get_log_level_descriptor(config.get('log_level')))
-
+    default_measurement = config.get('default_measurement')
     import_dashboards(dashboards, modules[0])
     converter = InfluxQLToM3DashboardConverter(datasource_map=datasource_mapping,
-                                               log_level=get_log_level_descriptor(config.get('log_level')))
+                                               log_level=get_log_level_descriptor(config.get('log_level')),
+                                               default_measurement=default_measurement)
     influx_dashboards = []
     convert_dashboards(converter, dashboards, influx_dashboards, invalid_dashboards)
     metric_to_objects = converter.metric_to_objects


### PR DESCRIPTION
- All the measurements does not need default expression so add it as a suggestion inside a comment
- Add more histogram regex

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does
* Add default expression as suggestion in the comments
* Add more histogram measurement regex

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
Resolves: #xxxxx

* Issue with some grafana panels not matching with influx when default expression is provided always.
* Issue with some grafana panels treating histogram metric as counter

# Why this way
* To give more control to the user on when to enable default expression.

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

